### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,10 +28,6 @@ jobs:
         source:
           - { repo: "qmk/qmk_firmware", branch: "master" }
           - { repo: "sigprof/qmk_firmware", branch: "nix-shell-updates" }
-        nixPath:
-          - nixpkgs=channel:nixos-21.05
-          - nixpkgs=channel:nixos-21.11
-          - nixpkgs=channel:nixos-unstable
         os:
           - ubuntu-latest
           - macos-10.15
@@ -43,7 +39,10 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v16
         with:
-          nix_path: "${{ matrix.nixPath }}"
+          # `nix-shell` gets `bashInteractive` from `<nixpkgs>`, so a valid
+          # `NIX_PATH` is required (there is a fallback to whatever `bash`
+          # binary is found in `$PATH`, but it might be a wrong version).
+          nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Show nixpkgs version
         run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,6 @@ jobs:
           - { repo: "sigprof/qmk_firmware", branch: "nix-shell-updates" }
         os:
           - ubuntu-latest
-          - macos-10.15
           - macos-11
       fail-fast: false
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Build the Nix shell environment
         id: nix_shell
-        run: nix-shell --run 'true'
+        run: nix-shell --show-trace --run 'true'
 
       - name: Test AVR build using 'make'
         if: ${{ always() && (steps.nix_shell.outcome == 'success') }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-11
+          - macos-12
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Update the CI testing workflow:
- Remove `nixPath` from the matrix and always use `nixos-unstable` (the only thing that is actually taken from `NIX_PATH` is the shell used by `nix-shell`, therefore testing with multiple `NIX_PATH` values is mostly useless).
- Add `--show-trace` to the first `nix-shell` invocation, so that debugging various issues would be easier.
- Remove `macos-10.15` from the test matrix (it is deprecated and scheduled to be removed: actions/virtual-environments#5583).
- Add `macos-12` to the test matrix (it is out of beta and might even become the default version soon).