### PR TITLE
Test the `develop` and `nix-shell-updates-develop` branches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,9 @@ jobs:
       matrix:
         source:
           - { repo: "qmk/qmk_firmware", branch: "master" }
+          - { repo: "qmk/qmk_firmware", branch: "develop" }
           - { repo: "sigprof/qmk_firmware", branch: "nix-shell-updates" }
+          - { repo: "sigprof/qmk_firmware", branch: "nix-shell-updates-develop" }
         os:
           - ubuntu-latest
           - macos-11


### PR DESCRIPTION
Try to catch any `develop` breakages before they graduate to `master`; also test the branch that will be used for PRs to `develop`.