### PR TITLE
CI: Ignore nonexistent and renamed branches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,10 +41,10 @@ jobs:
           script: |
             // Default settings.
             const defaultSource = [
-              { repo: "qmk/qmk_firmware", branch: "master" },
-              { repo: "qmk/qmk_firmware", branch: "develop" },
-              { repo: "sigprof/qmk_firmware", branch: "nix-shell-updates" },
-              { repo: "sigprof/qmk_firmware", branch: "nix-shell-updates-develop" },
+              { owner: "qmk",     repo: "qmk_firmware", branch: "master" },
+              { owner: "qmk",     repo: "qmk_firmware", branch: "develop" },
+              { owner: "sigprof", repo: "qmk_firmware", branch: "nix-shell-updates" },
+              { owner: "sigprof", repo: "qmk_firmware", branch: "nix-shell-updates-develop" },
             ];
             const defaultOS = [
               "ubuntu-latest",
@@ -71,7 +71,7 @@ jobs:
                   repoParts.push("qmk_firmware");
                 }
                 matrixSource = [
-                  { repo: repoParts.join("/"), branch: sourceParts[1] },
+                  { owner: repoParts[0], repo: repoParts[1], branch: sourceParts[1] },
                 ];
               }
             }
@@ -125,7 +125,7 @@ jobs:
       - name: Checkout the QMK source code
         uses: actions/checkout@v4.1.1
         with:
-          repository: ${{ matrix.source.repo }}
+          repository: ${{ format('{0}/{1}', matrix.source.owner, matrix.source.repo) }}
           ref: ${{ matrix.source.branch }}
           submodules: recursive
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,11 +82,30 @@ jobs:
               matrixOS = [ inputOS ];
             }
 
+            // Filter out nonexistent branches.
+            let filteredSource = [];
+            for (source of matrixSource) {
+              try {
+                branch = await github.rest.repos.getBranch(source);
+                if (branch.data.name == source.branch) {
+                  filteredSource.push(source);
+                } else {
+                  core.info(`Branch '${source.branch}' in '${source.owner}/${source.repo}' was renamed to '${branch.data.name}' - ignoring.`);
+                }
+              } catch (e) {
+                if (e.name === 'HttpError' && e.status === 404) {
+                  core.info(`Branch '${source.branch}' not found in '${source.owner}/${source.repo}'.`);
+                } else {
+                  throw e;
+                }
+              }
+            }
+
             // Determine build strategy.
             const strategy = {
               "fail-fast": false,
               "matrix": {
-                "source": matrixSource,
+                "source": filteredSource,
                 "os": matrixOS,
               },
             };


### PR DESCRIPTION
Branches for old PRs (like `nix-shell-updates`) started to give errors in CI, because they referred to some stale versions of `qmk_firmware`, and the Nix shell code in there was not compatible with the `aarch46-darwin` architecture, which `macos-latest` uses now.

Branches for pending PRs don't really need to exist when there is no corresponding open PR, so the best solution is to remove such PR branches immediately after they are no longer needed, and ignore nonexistent branches in this workflow.  This also avoids useless work during CI tests (testing the current state of `master` and `develop` is useful to detect any accidental breakage; testing some old branch which never gets updated is not really useful).

Apparently `github.rest.repos.getBranch()` follows branch renames, so it may return a branch with a different name from the requested one; ignore such branches too (they are probably archived PR branches which should not be tested by CI).