### PR TITLE
ci: Test `macos-13` in addition to `macos-latest`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,6 +48,7 @@ jobs:
             ];
             const defaultOS = [
               "ubuntu-latest",
+              "macos-13",
               "macos-latest",
             ];
 


### PR DESCRIPTION
`macos-latest` is now `macos-14`, which uses M1-based runners and therefore the `aarch64-darwin` architecture for Nix.  Add `macos-13` to the default test matrix, which is apparently the latest version which still uses `x86_64-darwin`.